### PR TITLE
add scroll to settings block container

### DIFF
--- a/app-core/main.css
+++ b/app-core/main.css
@@ -52,6 +52,7 @@ body{
 .settings-block {
     width: 100%;
     max-width: 400px;
+    overflow: auto;
     position: fixed;
     top:0;
     right: 0;


### PR DESCRIPTION
Without this fix is not possible to see all the settings in right sidebar
